### PR TITLE
Исправление FindAllComponent в ComponentUtility и другие изменения

### DIFF
--- a/Assets/Editor/ComponentUtility.cs
+++ b/Assets/Editor/ComponentUtility.cs
@@ -3,41 +3,60 @@ using UnityEngine;
 
 namespace Editor
 {
-    public static class ComponentUtility
-    {
-        public static T[] FindAllComponent<T>(this Transform parent, params Component[] validNames) where T : Component
-        {
-            var components = new List<T>(parent.childCount);
-            for (int i = 0; i < parent.childCount; i++)
-            {
-                var child = parent.GetChild(i);
-                var childChild = child.FindAllComponent<T>();
-                if (childChild != null && childChild.Length > 0)
-                {
-                    components.AddRange(childChild);
-                }
+	public static class ComponentUtility
+	{ 
+		public static T[] FindAllComponent<T>(this Transform parent, params Component[] validNames) where T : Component
+		{
+			if (parent == null)
+				return System.Array.Empty<T>();
 
-                var component = child.GetComponent<T>();
-                if (component != null)
-                {
-                    bool validName = false;
-                    foreach (var name in validNames)
-                    {
-                        if (component.transform.name == name.transform.name)
-                        {
-                            validName = true;
-                            break;
-                        }
-                    }
+			var components = new List<T>(parent.childCount);
+			
+			bool acceptAll = validNames == null || validNames.Length == 0;
 
-                    if (validName)
-                    {
-                        components.Add(component);
-                    }
-                }
-            }
+			for (int i = 0; i < parent.childCount; i++)
+			{
+				var child = parent.GetChild(i);
+				var childChild = child.FindAllComponent<T>(validNames);
 
-            return components.ToArray();
-        }
-    }
+				if (childChild != null && childChild.Length > 0)
+				{
+					components.AddRange(childChild);
+				}
+				
+				var component = child.GetComponent<T>();
+				if (component == null)
+				{
+					continue;
+				}
+
+				bool validName = false;
+				if (acceptAll)
+				{
+					validName = true;
+				}
+				else
+				{
+					foreach (var name in validNames)
+					{
+						if (name == null || name.transform == null || component.transform == null)
+							continue;
+						
+						if (component.transform.name == name.transform.name)
+						{
+							validName = true;
+							break;
+						}
+					}
+				}
+
+				if (validName)
+				{
+					components.Add(component);
+				}
+			}
+
+			return components.ToArray();
+		}
+	}
 }

--- a/Assets/Editor/MapMetaConfigDrawer.cs
+++ b/Assets/Editor/MapMetaConfigDrawer.cs
@@ -8,6 +8,7 @@ namespace Editor
     {
         private float m_height;
         private MapMetaConfig m_target;
+        private Vector2 scrollPosition;
         
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -68,20 +69,47 @@ namespace Editor
         }
 
         private void TextureProp(ref Rect position, SerializedProperty property, Vector2 size, Vector2 space)
-        {
-            var rectTexture = new Rect(position.position, new Vector2(size.x, size.y * ((float)9 / 16)));
-            property.objectReferenceValue = (Texture2D)EditorGUI.ObjectField(rectTexture, property.objectReferenceValue, typeof(Texture2D), false);
-            position.position += rectTexture.size * space;
-            position.size += rectTexture.size * space;
-        }
+		{
+			var rectTexture = new Rect(position.position, new Vector2(size.x, size.y * 9f / 16f));
+			property.objectReferenceValue = EditorGUI.ObjectField(rectTexture, property.objectReferenceValue, typeof(Texture2D), false);
+
+			if (property.objectReferenceValue != null)
+			{
+				var path = AssetDatabase.GetAssetPath(property.objectReferenceValue);
+				var importer = AssetImporter.GetAtPath(path) as TextureImporter;
+
+				if (importer != null && !importer.isReadable)
+				{
+					var buttonRect = new Rect(rectTexture.x, rectTexture.yMax + 2, rectTexture.width, 20);
+					if (GUI.Button(buttonRect, new GUIContent(" Fix Readable", EditorGUIUtility.IconContent("console.warnicon").image)))
+					{
+						importer.isReadable = true;
+						importer.SaveAndReimport();
+					}
+
+					position.position += new Vector2(0, 24);
+					position.size += new Vector2(0, 24);
+				}
+			}
+
+			position.position += rectTexture.size * space;
+			position.size += rectTexture.size * space;
+		}
         
         private void TextArea(ref Rect position, SerializedProperty property, Vector2 size, Vector2 space)
-        {
-            var rectTexture = new Rect(position.position, size);
-            property.stringValue = EditorGUI.TextArea(rectTexture, property.stringValue);
-            position.position += rectTexture.size * space;
-            position.size += rectTexture.size * space;
-        }
+		{
+			var style = new GUIStyle(EditorStyles.textArea) { wordWrap = true };
+			var rect = new Rect(position.position, size);
+
+			float textHeight = Mathf.Max(style.CalcHeight(new GUIContent(property.stringValue), rect.width), rect.height);
+
+			scrollPosition = GUI.BeginScrollView(rect, scrollPosition, new Rect(0, 0, rect.width - 16, textHeight));
+			property.stringValue = EditorGUI.TextArea(new Rect(0, 0, rect.width - 16, textHeight), property.stringValue, style);
+			GUI.EndScrollView();
+
+			position.position += rect.size * space;
+			position.size += rect.size * space;
+		}
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {


### PR DESCRIPTION
Изменил метод в ComponentUtility.
Теперь нормально обрабатываются случаи, когда родитель или дочерние объекты равны null.
Это убивало сборку карты в некоторых случаях, особенно после удаления вспомогательных скриптов, которые не являются валидными для SDK

<img width="1680" height="971" alt="image" src="https://github.com/user-attachments/assets/18242fb5-231c-4d8e-a66d-1ce6d867c10c" />
***

Изменил отрисовку поля ввода описания для карты, добавив скролл и перенос строки в рамках контейнера поля ввода. Так же добавил кнопку, которая позволяет быстро выставить Read/Write у текстуры, если этого ещё не сделано.

<img width="573" height="328" alt="image" src="https://github.com/user-attachments/assets/1840a021-6c6a-4bee-a253-f875be3ba0c1" />